### PR TITLE
Make CI run on PRs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
+/.idea
 /target
 /tiles

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,14 @@
-name: Lint, test, and publish
+name: Lint and test
 
 on:
   push:
     branches:
-      - develop
-  release:
-    types: [published]
+      - main
+  pull_request:
 
 jobs:
   tests:
     runs-on: ubuntu-latest
-    if: github.event_name != 'release'
     strategy:
       matrix:
         rust:
@@ -29,7 +27,7 @@ jobs:
         with:
           command: test
 
-  coverage_and_publish:
+  coverage:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -49,17 +47,10 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           path-to-lcov: './lcov.info'
-      - name: Publish to crates.io
-        if: github.event_name == 'release'
-        uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          args: --token ${{ secrets.CRATES_TOKEN }}
 
   lint:
     name: Linting
     runs-on: ubuntu-latest
-    if: github.event_name != 'release'
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,18 @@ jobs:
           toolchain: ${{ matrix.rust }}
           override: true
           components: rustfmt, clippy
-      - uses: actions-rs/cargo@v1
+      - name: Formatting (fmt)
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+      - name: Clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings
+      - name: Test
+        uses: actions-rs/cargo@v1
         with:
           command: test
 
@@ -47,23 +58,3 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           path-to-lcov: './lcov.info'
-
-  lint:
-    name: Linting
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add rustfmt clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+    branches: [main]
 
 jobs:
   tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-  
+
   coverage_and_publish:
     runs-on: ubuntu-latest
     steps:
@@ -56,8 +56,8 @@ jobs:
           command: publish
           args: --token ${{ secrets.CRATES_TOKEN }}
 
-  fmt:
-    name: Rustfmt
+  lint:
+    name: Linting
     runs-on: ubuntu-latest
     if: github.event_name != 'release'
     steps:
@@ -67,26 +67,12 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - run: rustup component add rustfmt
+      - run: rustup component add rustfmt clippy
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
-
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    if: github.event_name != 'release'
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy
       - uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: -- -D warnings
-          

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     branches: [main]
 
 jobs:
-  tests:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Lint and test
+name: CI
 
 on:
   push:
@@ -22,6 +22,20 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
           components: rustfmt, clippy
       - name: Formatting (fmt)
         uses: actions-rs/cargo@v1
@@ -33,12 +47,9 @@ jobs:
         with:
           command: clippy
           args: -- -D warnings
-      - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
 
   coverage:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: Publish to crates.io
+
+on:
+  release:
+    types: [published]
+
+jobs:
+
+  coverage_and_publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+        # TODO: On publish, do we need to run these two coverage steps?
+      - name: Generate coverage info
+        uses: actions-rs/tarpaulin@v0.1
+        with:
+          version: '0.18.0'
+          args: '-- --test-threads 1'
+          out-type: 'Lcov'
+      - name: Upload to coveralls.io
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          path-to-lcov: './lcov.info'
+      - name: Publish to crates.io
+        if: github.event_name == 'release'
+        uses: actions-rs/cargo@v1
+        with:
+          command: publish
+          args: --token ${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to crates.io
+name: Publish
 
 on:
   release:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /target
 **/*.rs.bk
 


### PR DESCRIPTION
* Combine fmt & clippy to simplify CI workflow. No need to spin up two VMs for this
* split publish from the rest of CI, and make CI run on PRs
* gitignore intellij