### PR TITLE
refactor to use tilejson crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
  "http",
@@ -456,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "os_str_bytes"
@@ -659,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -670,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "remove_dir_all"
@@ -846,8 +846,9 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "tilejson"
-version = "0.2.5-alpha.0"
-source = "git+https://github.com/nyurik/tilejson?branch=rfctr#74759a49fe416be71cbefe7ad95247ccd7ca3b23"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eeb0af84b43a1056a3c4768c91174f2daa12aa152853fc70719cd2a4832cb4e"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempdir",
+ "tilejson",
  "tokio",
 ]
 
@@ -750,6 +751,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_tuple"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f025b91216f15a2a32aa39669329a475733590a015835d1783549a56d09427"
+dependencies = [
+ "serde",
+ "serde_tuple_macros",
+]
+
+[[package]]
+name = "serde_tuple_macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4076151d1a2b688e25aaf236997933c66e18b870d0369f8b248b8ab2be630d7e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -821,6 +843,16 @@ name = "textwrap"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+
+[[package]]
+name = "tilejson"
+version = "0.2.5-alpha.0"
+source = "git+https://github.com/nyurik/tilejson?branch=rfctr#74759a49fe416be71cbefe7ad95247ccd7ca3b23"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_tuple",
+]
 
 [[package]]
 name = "tokio"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ regex = "1.5"
 rusqlite = "0.27"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tilejson = { git = "https://github.com/nyurik/tilejson", branch = "rfctr" }
 tokio = { version = "1.18", features = ["full"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ regex = "1.5"
 rusqlite = "0.27"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tilejson = { git = "https://github.com/nyurik/tilejson", branch = "rfctr" }
+tilejson = "0.3"
 tokio = { version = "1.18", features = ["full"] }
 
 [dev-dependencies]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -32,7 +32,8 @@ impl fmt::Display for Error {
                 write!(f, "Invalid query category: {tile_name}")
             }
             Error::UnknownTileFormat(tile_name) => write!(f, "Unknown tile format: {tile_name}"),
-            _ => write!(f, "{self}"),
+            Error::DBConnection(_) => write!(f, "Database connection error"),
+            Error::Pool(_) => write!(f, "Database pool connection error"),
         }
     }
 }

--- a/src/tiles.rs
+++ b/src/tiles.rs
@@ -283,44 +283,47 @@ mod tests {
 
     #[test]
     fn get_tileset_metadata() {
-        let metadata = get_tile_details(
+        let tileset_details = get_tile_details(
             &PathBuf::from("./tiles/geography-class-png.mbtiles"),
             "geography-class-png",
         )
         .unwrap();
         // The rhs values are from metadata table of geography-class-png.mbtiles
-        assert_eq!(metadata.tilejson.name.unwrap(), "Geography Class");
-        assert_eq!(metadata.tilejson.version.unwrap(), "1.0.0");
-        assert_eq!(metadata.tilejson.minzoom.unwrap(), 0);
-        assert_eq!(metadata.tilejson.maxzoom.unwrap(), 1);
+        assert_eq!(tileset_details.tilejson.name.unwrap(), "Geography Class");
+        assert_eq!(tileset_details.tilejson.version.unwrap(), "1.0.0");
+        assert_eq!(tileset_details.tilejson.minzoom.unwrap(), 0);
+        assert_eq!(tileset_details.tilejson.maxzoom.unwrap(), 1);
         assert_eq!(
-            metadata.tilejson.bounds.unwrap(),
+            tileset_details.tilejson.bounds.unwrap(),
             Bounds::new(-180.0, -85.0511, 180.0, 85.0511)
         );
-        assert_eq!(metadata.tilejson.center.unwrap(), Center::new(0.0, 20.0, 0));
-        assert_eq!(metadata.tile_format, DataFormat::Png);
+        assert_eq!(
+            tileset_details.tilejson.center.unwrap(),
+            Center::new(0.0, 20.0, 0)
+        );
+        assert_eq!(tileset_details.tile_format, DataFormat::Png);
 
-        let metadata = get_tile_details(
+        let tileset_details = get_tile_details(
             &PathBuf::from("./tiles/world_cities.mbtiles"),
             "world_cities",
         )
         .unwrap();
         // The rhs values are from metadata table of world_cities.mbtiles
         assert_eq!(
-            metadata.tilejson.name.unwrap(),
+            tileset_details.tilejson.name.unwrap(),
             "Major cities from Natural Earth data"
         );
-        assert_eq!(metadata.tilejson.version.unwrap(), "2");
-        assert_eq!(metadata.tilejson.minzoom.unwrap(), 0);
-        assert_eq!(metadata.tilejson.maxzoom.unwrap(), 6);
+        assert_eq!(tileset_details.tilejson.version.unwrap(), "2");
+        assert_eq!(tileset_details.tilejson.minzoom.unwrap(), 0);
+        assert_eq!(tileset_details.tilejson.maxzoom.unwrap(), 6);
         assert_eq!(
-            metadata.tilejson.bounds.unwrap(),
+            tileset_details.tilejson.bounds.unwrap(),
             Bounds::new(-123.123590, -37.818085, 174.763027, 59.352706)
         );
         assert_eq!(
-            metadata.tilejson.center.unwrap(),
+            tileset_details.tilejson.center.unwrap(),
             Center::new(-75.937500, 38.788894, 6)
         );
-        assert_eq!(metadata.tile_format, DataFormat::Pbf);
+        assert_eq!(tileset_details.tile_format, DataFormat::Pbf);
     }
 }


### PR DESCRIPTION
* Use unpublished [version](https://github.com/nyurik/tilejson/tree/rfctr) of tilejson
* The TileJSON is used as a sub-object of TileMeta
* The TileJSON is used to generate tilejson response
* Fix infinite loop in Error display

## ✔️ PR Todo

- [x] Switch to published version once https://github.com/georust/tilejson/pull/16 to be merged and published